### PR TITLE
Simplify print output for SARIMA/RegARIMA

### DIFF
--- a/R/display.R
+++ b/R/display.R
@@ -238,9 +238,9 @@ print.summary.JD3_LIKELIHOOD<-function(x, ...){
   cat("Loglikelihood:", x$ll)
   if (x$ll != x$adjustedll)cat(", Adjusted loglikelihood:", x$adjustedll)
   cat("\nStandard error of the regression (ML estimate):", x$se, "\n")
-  cat("AIC:", x$aic, ", ")
-  cat("AICc:", x$aicc, ", ")
-  cat("BIC:", x$bic, "\n")
+  cat("AIC: ", x$aic, ", ",
+      "AICc: ", x$aicc, ", ",
+      "BIC: ", x$bic, "\n", sep = "")
   invisible(x)
 }
 

--- a/R/display.R
+++ b/R/display.R
@@ -6,6 +6,7 @@ NULL
 #'
 #' @param x the object to print.
 #' @param digits minimum number of significant digits to be used for most numbers.
+#' @param summary_info boolean indicating if a message suggesting the use of the summary function for more details should be printed. By default used the option `"summary_info"` it used, which initialized to `TRUE`.
 #' @param ... further unused parameters.
 #' @name jd3_print
 #' @rdname jd3_print
@@ -61,15 +62,13 @@ print.JD3_SARIMA_ESTIMATION<-function(x, digits = max(3L, getOption("digits") - 
 
   cat("\n")
 
-  cat("\nCoefficients\n")
+  cat("\nSARIMA coefficients:\n")
   if (is.null(tables$coef_table)){
     cat("No SARIMA variables\n")
-  } else if (ncol(tables$coef_table) == 2){
-    print(tables$coef_table)
   } else {
-    printCoefmat(tables$coef_table[-2], digits = digits,
-                 P.values= FALSE,
-                 na.print = "NA", ...)
+    coef <- tables$coef_table[, 1]
+    names(coef) <- rownames(tables$coef_table)
+    print(coef, digits = digits, na.print = "NA", ...)
   }
   invisible(x)
 }
@@ -98,7 +97,7 @@ print.summary.JD3_SARIMA_ESTIMATION<-function(x, digits = max(3L, getOption("dig
   if (is.null(x$coef_table)){
     cat("No SARIMA variables\n")
   } else if (ncol(x$coef_table) == 2){
-    print(x$coef_table)
+    print(x$coef_table, ...)
   } else {
     printCoefmat(x$coef_table[-2], digits = digits, signif.stars = signif.stars,
                  na.print = "NA", ...)
@@ -248,7 +247,7 @@ print.summary.JD3_LIKELIHOOD<-function(x, ...){
 
 #' @rdname jd3_print
 #' @export
-print.JD3_REGARIMA_RSLTS<-function(x, digits = max(3L, getOption("digits") - 3L), ...){
+print.JD3_REGARIMA_RSLTS<-function(x, digits = max(3L, getOption("digits") - 3L), summary_info = getOption("summary_info"), ...){
   cat("Log-transformation:",if (x$description$log) {"yes"} else {"no"},
       "\n", sep=" ")
 
@@ -261,15 +260,19 @@ print.JD3_REGARIMA_RSLTS<-function(x, digits = max(3L, getOption("digits") - 3L)
   cat("\n")
   if (!is.null(xregs)){
     cat("Regression model:\n")
-    printCoefmat(xregs[-2], digits = digits, P.values= FALSE, na.print = "NA", ...)
+    xregs_coef <- xregs[,1]
+    names(xregs_coef) <- rownames(xregs)
+    print(xregs_coef, digits = digits, na.print = "NA", ...)
   } else {
     cat("No regression variables\n")
   }
-  print(x$estimation$likelihood, ...)
+  if (summary_info)
+    cat("\nFor a more detailed output, use the 'summary()' function.\n")
+
   invisible(x)
 }
 #' @export
-print.JD3_SARIMA_ESTIMATE<-function(x, digits = max(3L, getOption("digits") - 3L), ...){
+print.JD3_SARIMA_ESTIMATE<-function(x, digits = max(3L, getOption("digits") - 3L), summary_info = getOption("summary_info"), ...){
 
   tables <- .sarima_coef_table(x, ...)
   orders <- tables$sarima_orders
@@ -284,23 +287,24 @@ print.JD3_SARIMA_ESTIMATE<-function(x, digits = max(3L, getOption("digits") - 3L
 
   cat("\nCoefficients\n")
   if (is.null(tables$coef_table)){
-    cat("No SARIMA variables\n")
-  } else if (ncol(tables$coef_table) == 2){
-    print(tables$coef_table)
+      cat("No SARIMA variables\n")
   } else {
-    printCoefmat(tables$coef_table[-2], digits = digits,
-                 P.values= FALSE,
-                 na.print = "NA", ...)
+      coef <- tables$coef_table[, 1]
+      names(coef) <- rownames(tables$coef_table)
+      print(coef, digits = digits, na.print = "NA", ...)
   }
   xregs <- .regarima_coef_table(x, ...)
   cat("\n")
   if (!is.null(xregs)){
     cat("Regression model:\n")
-    printCoefmat(xregs[-2], digits = digits, P.values= FALSE, na.print = "NA", ...)
+    xregs_coef <- xregs[,1]
+    names(xregs_coef) <- rownames(xregs)
+    print(xregs_coef, digits = digits, na.print = "NA", ...)
   } else {
     cat("No regression variables\n")
   }
-  # print(x$likelihood, ...) # likelihood not printed but in summary method
+  if (summary_info)
+      cat("\nFor a more detailed output, use the 'summary()' function.\n")
   invisible(x)
 }
 .regarima_coef_table <- function(x,...){

--- a/R/display.R
+++ b/R/display.R
@@ -15,9 +15,9 @@ print.JD3_ARIMA<-function(x, ...){
   m <- x
   if (m$var > 0 || length(m$delta)>1){
     cat(m$name, "\n\n")
-    if (length(m$ar)>1) cat("AR: ", m$ar, "\n")
-    if (length(m$delta)>1)cat("DIF: ", m$delta, "\n")
-    if (length(m$ma)>1)cat("MA: ", m$ma, "\n")
+    if (length(m$ar)>1) cat("AR:", m$ar, "\n")
+    if (length(m$delta)>1)cat("DIF:", m$delta, "\n")
+    if (length(m$ma)>1)cat("MA:", m$ma, "\n")
     cat("var: ", m$var, "\n\n")
   }
   invisible(x)
@@ -43,10 +43,10 @@ print.JD3_UCARIMA<-function(x,...){
 print.JD3_SARIMA<-function(x, ...){
   m <- x
   cat("SARIMA model: ", .arima_node(length(m$phi), m$d, length(m$theta)), .arima_node(length(m$bphi), m$bd, length(m$btheta)), m$period, "\n")
-  if (length(m$phi)>0) cat("phi: ", m$phi, "\n")
-  if (length(m$theta)>0)cat("theta: ", m$theta, "\n")
-  if (length(m$bphi)>0) cat("bphi: ", m$bphi, "\n")
-  if (length(m$btheta)>0)cat("btheta: ", m$btheta, "\n")
+  if (length(m$phi)>0) cat("phi:", m$phi, "\n")
+  if (length(m$theta)>0)cat("theta:", m$theta, "\n")
+  if (length(m$bphi)>0) cat("bphi:", m$bphi, "\n")
+  if (length(m$btheta)>0)cat("btheta:", m$btheta, "\n")
 }
 #' @rdname jd3_print
 #' @export
@@ -54,7 +54,7 @@ print.JD3_SARIMA_ESTIMATION<-function(x, digits = max(3L, getOption("digits") - 
   tables <- .sarima_coef_table(x, ...)
   orders <- tables$sarima_orders
 
-  cat("SARIMA model: ",
+  cat("SARIMA model:",
       .arima_node(orders$p, orders$d, orders$q),
       .arima_node(orders$bp, orders$bd, orders$bq))
   if (!is.null(orders$period)) # when sarima_estimate() is used
@@ -86,7 +86,7 @@ summary.JD3_SARIMA_ESTIMATION<-function(object, ...){
 print.summary.JD3_SARIMA_ESTIMATION<-function(x, digits = max(3L, getOption("digits") - 3L), signif.stars = getOption("show.signif.stars"), ...){
   orders <- x$sarima_orders
 
-  cat("SARIMA model: ",
+  cat("SARIMA model:",
       .arima_node(orders$p, orders$d, orders$q),
       .arima_node(orders$bp, orders$bd, orders$bq))
   if (!is.null(orders$period)) # when sarima_estimate() is used
@@ -203,15 +203,15 @@ print.JD3_SPAN <- function(x, ...){
 #' @export
 print.JD3_LIKELIHOOD<-function(x, ...){
   ll <- x
-  cat("Number of observations: ", ll$nobs, "\n")
-  cat("Number of effective observations: ", ll$neffectiveobs, "\n")
-  cat("Number of parameters: ", ll$nparams, "\n\n")
-  cat("Loglikelihood: ", ll$ll, "\n")
-  if (ll$ll != ll$adjustedll)cat("Adjusted loglikelihood: ", ll$adjustedll, "\n\n")
-  cat("Standard error of the regression (ML estimate): ", sqrt(ll$ssq/ll$neffectiveobs), "\n")
-  cat("AIC: ", ll$aic, "\n")
-  cat("AICC: ", ll$aicc, "\n")
-  cat("BIC: ", ll$bic, "\n\n")
+  cat("Number of observations:", ll$nobs, "\n")
+  cat("Number of effective observations:", ll$neffectiveobs, "\n")
+  cat("Number of parameters:", ll$nparams, "\n\n")
+  cat("Loglikelihood:", ll$ll, "\n")
+  if (ll$ll != ll$adjustedll)cat("Adjusted loglikelihood:", ll$adjustedll, "\n\n")
+  cat("Standard error of the regression (ML estimate):", sqrt(ll$ssq/ll$neffectiveobs), "\n")
+  cat("AIC:", ll$aic, "\n")
+  cat("AICC:", ll$aicc, "\n")
+  cat("BIC:", ll$bic, "\n\n")
   invisible(x)
 }
 #' @export
@@ -234,13 +234,13 @@ summary.JD3_LIKELIHOOD<-function(object, ...){
 print.summary.JD3_LIKELIHOOD<-function(x, ...){
   cat("Number of observations: ", x$nobs,
       ", Number of effective observations: ", x$neffectiveobs,
-      ", Number of parameters: ", x$nparams, "\n")
-  cat("Loglikelihood: ", x$ll)
-  if (x$ll != x$adjustedll)cat(", Adjusted loglikelihood: ", x$adjustedll)
-  cat("\nStandard error of the regression (ML estimate): ", x$se, "\n")
-  cat("AIC: ", x$aic, ", ")
-  cat("AICc: ", x$aicc, ", ")
-  cat("BIC: ", x$bic, "\n")
+      ", Number of parameters: ", x$nparams, "\n", sep = "")
+  cat("Loglikelihood:", x$ll)
+  if (x$ll != x$adjustedll)cat(", Adjusted loglikelihood:", x$adjustedll)
+  cat("\nStandard error of the regression (ML estimate):", x$se, "\n")
+  cat("AIC:", x$aic, ", ")
+  cat("AICc:", x$aicc, ", ")
+  cat("BIC:", x$bic, "\n")
   invisible(x)
 }
 
@@ -277,7 +277,7 @@ print.JD3_SARIMA_ESTIMATE<-function(x, digits = max(3L, getOption("digits") - 3L
   tables <- .sarima_coef_table(x, ...)
   orders <- tables$sarima_orders
 
-  cat("SARIMA model: ",
+  cat("SARIMA model:",
       .arima_node(orders$p, orders$d, orders$q),
       .arima_node(orders$bp, orders$bd, orders$bq))
   if (!is.null(orders$period)) # when sarima_estimate() is used

--- a/R/display.R
+++ b/R/display.R
@@ -375,6 +375,9 @@ summary.JD3_SARIMA_ESTIMATE <-function(object, ...){
 }
 #' @export
 print.summary.JD3_REGARIMA_RSLTS <- function(x,  digits = max(3L, getOption("digits") - 3L), signif.stars = getOption("show.signif.stars"), ...){
+  if (!is.null(x$method)) # Used to add the method when regarima/tramo function is used
+      cat("Method:", x$method, "\n")
+
   if (!is.null(x$log))
     cat("Log-transformation:",if (x$log) {"yes"} else {"no"},"\n",sep=" ")
 

--- a/R/tests_regular.R
+++ b/R/tests_regular.R
@@ -35,8 +35,8 @@ statisticaltest<-function(val, pval, dist=NULL){
 #' @rdname statisticaltest
 #' @export
 print.JD3_TEST<-function(x, details=FALSE, ...){
-  cat('Value: ', x$value, '\n')
-  cat('P-Value: ', sprintf('%.4f', x$pvalue), '\n')
+  cat('Value:', x$value, '\n')
+  cat('P-Value:', sprintf('%.4f', x$pvalue), '\n')
   if (details){
     dist<-attr(x, "distribution")
     if (! is.null(dist)){

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -32,4 +32,7 @@ NULL
   DATE_MIN<<-dateOf(1,1,1)
   DATE_MAX<<-dateOf(9999, 12, 31)
 
+  if(is.null(getOption("summary_info")))
+      options(summary_info = TRUE)
+
 }

--- a/man/jd3_print.Rd
+++ b/man/jd3_print.Rd
@@ -23,7 +23,12 @@
 
 \method{print}{JD3_LIKELIHOOD}(x, ...)
 
-\method{print}{JD3_REGARIMA_RSLTS}(x, digits = max(3L, getOption("digits") - 3L), ...)
+\method{print}{JD3_REGARIMA_RSLTS}(
+  x,
+  digits = max(3L, getOption("digits") - 3L),
+  summary_info = getOption("summary_info"),
+  ...
+)
 }
 \arguments{
 \item{x}{the object to print.}
@@ -31,6 +36,8 @@
 \item{...}{further unused parameters.}
 
 \item{digits}{minimum number of significant digits to be used for most numbers.}
+
+\item{summary_info}{boolean indicating if a message suggesting the use of the summary function for more details should be printed. By default used the option \code{"summary_info"} it used, which initialized to \code{TRUE}.}
 }
 \description{
 JD3 print functions


### PR DESCRIPTION
I propose to simplify the print output of the SARIMA/RegARIMA and seasonal adjustment models. A message with a reference to the `summary()` method is added (which can be disabled with the `summary_info `option):
``` r
library(rjd3toolkit)
library(rjd3x13)
y <- rjd3toolkit::ABS$X0.2.09.10.M
sa_e <- sarima_estimate(y, order = c(0,1,1), seasonal = c(0,1,1))
reg <- regarima(y)
sa_e
#> SARIMA model: (0,1,1) (0,1,1) [12]
#> 
#> Coefficients
#>  theta(1) btheta(1) 
#>   -0.8764   -0.3875 
#> 
#> No regression variables
#> 
#> For a more detailed output, use the 'summary()' function.
summary(sa_e) # not changed
#> SARIMA model: (0,1,1) (0,1,1) [12]
#> 
#> Coefficients
#>           Estimate Std. Error  T-stat Pr(>|t|)    
#> theta(1)  -0.87640    0.02290 -38.274  < 2e-16 ***
#> btheta(1) -0.38754    0.05071  -7.642 1.54e-13 ***
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
#> 
#> No regression variables
#> Number of observations: 425, Number of effective observations: 412, Number of parameters: 3
#> Loglikelihood: -2218.964
#> Standard error of the regression (ML estimate): 52.59137 
#> AIC: 4443.928, AICc: 4443.987, BIC: 4455.991
reg
#> Log-transformation: yes 
#> SARIMA model: (2,1,1) (0,1,1)
#> 
#> SARIMA coefficients:
#>    phi(1)    phi(2)  theta(1) btheta(1) 
#>    0.3474    0.2173   -0.6994   -0.4804 
#> 
#> Regression model:
#>              td          easter TC (2000-06-01) AO (2000-07-01) 
#>        0.002323        0.052011        0.159034       -0.290077 
#> 
#> For a more detailed output, use the 'summary()' function.
summary(reg) # not changed
#> Log-transformation: yes 
#> SARIMA model: (2,1,1) (0,1,1)
#> 
#> Coefficients
#>           Estimate Std. Error  T-stat Pr(>|t|)    
#> phi(1)     0.34740    0.06502   5.343 1.53e-07 ***
#> phi(2)     0.21733    0.06000   3.622 0.000329 ***
#> theta(1)  -0.69937    0.05115 -13.672  < 2e-16 ***
#> btheta(1) -0.48038    0.06993  -6.869 2.45e-11 ***
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
#> 
#> Regression model:
#>                   Estimate Std. Error T-stat Pr(>|t|)    
#> td               0.0023233  0.0006844  3.395 0.000755 ***
#> easter           0.0520113  0.0084894  6.127 2.14e-09 ***
#> TC (2000-06-01)  0.1590340  0.0288578  5.511 6.38e-08 ***
#> AO (2000-07-01) -0.2900774  0.0400551 -7.242 2.26e-12 ***
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
#> Number of observations: 425, Number of effective observations: 412, Number of parameters: 9
#> Loglikelihood: 746.7517, Adjusted loglikelihood: -2120.875
#> Standard error of the regression (ML estimate): 0.03927991 
#> AIC: 4259.75, AICc: 4260.198, BIC: 4295.939
```