### PR TITLE
new type in .proc_data and .jd2r_regression_item

### DIFF
--- a/R/jd2r.R
+++ b/R/jd2r.R
@@ -14,6 +14,17 @@ NULL
   }
 }
 
+
+.jd2r_regression_item <- function(s) {
+    desc <- .jcall(s, "S", "getDescription")
+    val <- .jcall(s, "D", "getCoefficient")
+    stderr <- .jcall(s, "D", "getStdError")
+    pval <- .jcall(s, "D", "getPvalue")
+    res <- matrix(c(val, stderr, val/stderr, pval), nrow = 1)
+    colnames(res) <- c("Estimate", "Std. Error", "T-stat", "Pr(>|t|)")
+    rownames(res) <- desc
+    res
+}
 #' @export
 #' @rdname jd3_utilities
 .r2jd_tsdata<-function(s){

--- a/R/jd3rslts.R
+++ b/R/jd3rslts.R
@@ -131,6 +131,8 @@
     return(.jevalArray(s, silent=TRUE))
   else if (.jinstanceof(s, "jdplus/toolkit/base/api/stats/StatisticalTest")) {
     return(.jd2r_test(s))
+  } else if (.jinstanceof(s, "jdplus/toolkit/base/api/timeseries/regression/RegressionItem")){
+      return(.jd2r_regression_item(s))
   }
   else
     return(.jcall(s, "S", "toString"))


### PR DESCRIPTION
To improve the export of some outputs, e.g.:
``` r
sa_model <- rjd3x13::.jx13(rjd3toolkit::ABS$X0.2.09.10.M)
rjd3toolkit::result(sa_model, "regression.out(1)")
#>             Estimate Std. Error   T-stat     Pr(>|t|)
#> TC (6-2000) 0.159034 0.02885775 5.510962 6.370459e-08
```